### PR TITLE
Add ArucoMarkers.msg and PointArray.msg

### DIFF
--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -13,10 +13,15 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
+find_package(geometry_msgs REQUIRED)
+
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/SixFloats.msg"
   "msg/LiveTune.msg"
   "msg/PIDmsg.msg"
+  "msg/ArucoMarkers.msg"
+  "msg/PointArray.msg"
+  DEPENDENCIES geometry_msgs # Add packages that above messages depend on
  )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/src/interfaces/msg/ArucoMarkers.msg
+++ b/src/interfaces/msg/ArucoMarkers.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+
+int64[] marker_ids
+geometry_msgs/Point[] points

--- a/src/interfaces/msg/PointArray.msg
+++ b/src/interfaces/msg/PointArray.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+
+geometry_msgs/Point[] points

--- a/src/interfaces/package.xml
+++ b/src/interfaces/package.xml
@@ -9,6 +9,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
+  
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
Created a PointArray.msg which is copied from [PoseArray.msg](https://github.com/ros2/common_interfaces/blob/humble/geometry_msgs/msg/PoseArray.msg) but for points.

Created a ArucoMarkers.msg which is copied from the [ros2_aruco package](https://github.com/JMU-ROBOTICS-VIVA/ros2_aruco/blob/main/ros2_aruco_interfaces/msg/ArucoMarkers.msg) but I changed it from Pose to Point because the ZED doesn't give me the angle of the marker.

If you require something from the geometry_msgs for any reason, I can switch to using PoseArray and just ignoring the quaternion component