### PR TITLE
Localization fixes

### DIFF
--- a/src/drive/drive/encoder_wrapper.py
+++ b/src/drive/drive/encoder_wrapper.py
@@ -55,8 +55,9 @@ class EncoderWrapper:
         return angle
 
     def update(self, enc_left, enc_right):
+        # Hack solution to accomidate for reversing motor 1 is make it negative
         left_ticks = enc_left - self.last_enc_left
-        right_ticks = enc_right - self.last_enc_right
+        right_ticks = -(enc_right - self.last_enc_right)
         self.last_enc_left = enc_left
         self.last_enc_right = enc_right
 

--- a/src/ros2_rover/rover_description/robots/rover.urdf.xacro
+++ b/src/ros2_rover/rover_description/robots/rover.urdf.xacro
@@ -214,7 +214,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. -->
     </xacro:sensor_imu>
 
     <xacro:sensor_asus_xtion prefix="camera" parent="base_link">
-        <origin xyz="0.215 0 0.065" rpy="0 0.5 0"/>
+        <origin xyz="0.215 0 0.065" rpy="0 0 4.71238898"/>
         <!-- <origin xyz="0.212 0 0.065" rpy="0 0 0"/> -->
     </xacro:sensor_asus_xtion>
 

--- a/src/ros2_rover/rover_localization/config/driver_params.yaml
+++ b/src/ros2_rover/rover_localization/config/driver_params.yaml
@@ -47,7 +47,7 @@ ouster/os_driver:
     # assigned.
     imu_port: 0
     # sensor_frame[optional]: name to use when referring to the sensor frame.
-    sensor_frame: base_link
+    sensor_frame: camera_link
     # lidar_frame[optional]: name to use when referring to the lidar frame.
     lidar_frame: os_lidar
     # imu_frame[optional]: name to use when referring to the imu frame.

--- a/src/ros2_rover/rover_localization/config/ekf_global.yaml
+++ b/src/ros2_rover/rover_localization/config/ekf_global.yaml
@@ -70,7 +70,7 @@ global_ekf:
     odom1_differential: false
     odom1_relative: false
 
-    odom2: wheels/odom
+    odom2: odom_roboclaw
     odom2_config: [
         # position
         false, false, false,

--- a/src/ros2_rover/rover_localization/config/ekf_local.yaml
+++ b/src/ros2_rover/rover_localization/config/ekf_local.yaml
@@ -41,7 +41,7 @@ local_ekf:
     # odom0_pose_rejection_threshold: 5.0
     # odom0_twist_rejection_threshold: 1.0
 
-    odom1: wheels/odom
+    odom1: odom_roboclaw
     odom1_config: [
         # position
         false, false, false,


### PR DESCRIPTION
Fix reversed M1 encoder ticks

Use old urdf (the open source one) to rotate the lidar 90 degrees to match the rover ( this is a temp fix till our real urdf comes in)

Set the topic name for the encoder odom topic
