### PR TITLE
feat: use symlink dev

### DIFF
--- a/src/drive/launch/RoverDriveWithJoystick.launch.py
+++ b/src/drive/launch/RoverDriveWithJoystick.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
             executable='roboclaw_node',
             name='roboclaw_node',
             parameters=[
-                {'dev': '/dev/ttyACM0'},
+                {'dev': '/dev/roboclaws/front'},
                 {'baud': 115200},
                 {'address': 128},
                 {'max_speed': 1.0},
@@ -42,7 +42,7 @@ def generate_launch_description():
             executable='roboclaw_node',
             name='roboclaw_node',
             parameters=[
-                {'dev': '/dev/ttyACM1'},
+                {'dev': '/dev/roboclaws/mid'},
                 {'baud': 115200},
                 {'address': 128},
                 {'max_speed': 1.0},
@@ -59,7 +59,7 @@ def generate_launch_description():
             executable='roboclaw_node',
             name='roboclaw_node',
             parameters=[
-                {'dev': '/dev/ttyACM2'},
+                {'dev': '/dev/roboclaws/back'},
                 {'baud': 115200},
                 {'address': 128},
                 {'max_speed': 1.0},

--- a/src/rover_localization/config/ekf_global.yaml
+++ b/src/rover_localization/config/ekf_global.yaml
@@ -50,7 +50,7 @@ global_ekf:
     odom1_differential: false
     odom1_relative: false
 
-    odom2: /dev/ttyACM0/odom_roboclaw
+    odom2: /dev/roboclaws/front/odom_roboclaw
     odom2_config: [
         # position
         false, false, false,
@@ -70,7 +70,7 @@ global_ekf:
     # odom2_pose_rejection_threshold: 5.0
     # odom2_twist_rejection_threshold: 1.0
 
-    odom3: /dev/ttyACM1/odom_roboclaw
+    odom3: /dev/roboclaws/mid/odom_roboclaw
     odom3_config: [
         # position
         false, false, false,
@@ -90,7 +90,7 @@ global_ekf:
     # odom3_pose_rejection_threshold: 5.0
     # odom3_twist_rejection_threshold: 1.0
 
-    odom4: /dev/ttyACM2/odom_roboclaw
+    odom4: /dev/roboclaws/back/odom_roboclaw
     odom4_config: [
         # position
         false, false, false,

--- a/src/rover_localization/config/ekf_local.yaml
+++ b/src/rover_localization/config/ekf_local.yaml
@@ -41,7 +41,7 @@ local_ekf:
     # odom0_pose_rejection_threshold: 5.0
     # odom0_twist_rejection_threshold: 1.0
 
-    odom1: /dev/ttyACM2/odom_roboclaw
+    odom1: /dev/roboclaws/front/odom_roboclaw
     odom1_config: [
         # position
         false, false, false,
@@ -61,7 +61,7 @@ local_ekf:
     # odom1_pose_rejection_threshold: 5.0
     # odom1_twist_rejection_threshold: 1.0
 
-    odom2: /dev/ttyACM0/odom_roboclaw
+    odom2: /dev/roboclaws/mid/odom_roboclaw
     odom2_config: [
         # position
         false, false, false,
@@ -81,7 +81,7 @@ local_ekf:
     # odom2_pose_rejection_threshold: 5.0
     # odom2_twist_rejection_threshold: 1.0
 
-    odom3: /dev/ttyACM1/odom_roboclaw
+    odom3: /dev/roboclaws/back/odom_roboclaw
     odom3_config: [
         # position
         false, false, false,


### PR DESCRIPTION
The front, mid and back are based on the port the usb is plugged into. The port matters!! The roboclaws do not implement any unique identifier to the kernel and therefore can not be identified without the help of knowing which port they are plugged into.