### PR TITLE
Update firstTimeInstall.sh source the cprt_bash_aliases from bashrc

### DIFF
--- a/cprt_bash_aliases
+++ b/cprt_bash_aliases
@@ -4,5 +4,5 @@
 # firstTimeInstall.sh will handle adding code to bashrc to source this file
 
 cprt_bash_alias_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-export CPRT_BASH_ALIAS_FILE="$cprt_bash_alias_dir/cprt_bash_aliases"
-alias eaCPRT='vim $CPRT_BASH_ALIAS_FILE'
+export BASH_ALIASES_CPRT="$cprt_bash_alias_dir/cprt_bash_aliases"
+alias eaCPRT='vim $BASH_ALIASES_CPRT && source ~/.bashrc && echo "CPRT Bash Aliases Updated"'

--- a/cprt_bash_aliases
+++ b/cprt_bash_aliases
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# CPRT bash aliases
+# firstTimeInstall.sh will handle adding code to bashrc to source this file
+
+cprt_bash_alias_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+export CPRT_BASH_ALIAS_FILE="$cprt_bash_alias_dir/cprt_bash_aliases"
+alias eaCPRT='vim $CPRT_BASH_ALIAS_FILE'

--- a/firstTimeInstall.sh
+++ b/firstTimeInstall.sh
@@ -3,6 +3,7 @@
 locale  # check for UTF-8
 
 set -e
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 sudo apt update && sudo apt install -y locales
 sudo locale-gen en_US en_US.UTF-8
@@ -37,6 +38,13 @@ source /opt/ros/humble/setup.bash
 if ! grep -q "source /opt/ros/humble/setup.bash" ~/.bashrc; then
   echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
   echo "ROS 2 sourced in bashrc"
+fi
+
+# Add lines in .bashrc to source the cprt_bash_aliases file if it exists
+if ! grep -qF "cprt_bash_aliases" ~/.bashrc; then
+   echo "if [ -f "$SCRIPT_DIR/cprt_bash_aliases" ]; then"  >> ~/.bashrc
+   echo "   . $SCRIPT_DIR/cprt_bash_aliases"               >> ~/.bashrc
+   echo "fi"                                               >> ~/.bashrc
 fi
 
 pip3 install black

--- a/firstTimeInstall.sh
+++ b/firstTimeInstall.sh
@@ -42,9 +42,11 @@ fi
 
 # Add lines in .bashrc to source the cprt_bash_aliases file if it exists
 if ! grep -qF "cprt_bash_aliases" ~/.bashrc; then
-   echo "if [ -f "$SCRIPT_DIR/cprt_bash_aliases" ]; then"  >> ~/.bashrc
-   echo "   . $SCRIPT_DIR/cprt_bash_aliases"               >> ~/.bashrc
-   echo "fi"                                               >> ~/.bashrc
+   {
+      echo "if [ -f $SCRIPT_DIR/cprt_bash_aliases ]; then"
+      echo "   . $SCRIPT_DIR/cprt_bash_aliases"
+      echo "fi"
+   } >> ~/.bashrc
 fi
 
 pip3 install black


### PR DESCRIPTION
Adds some code into the firstTimeInstall.sh to source our own bash aliases file. Has safety checks that will only put one copy of this code into the bashrc and will only try to source our bash alias file if it exists.

Also created a eaCPRT alias to edit the CPRT alias file.